### PR TITLE
:bug: fix localCommands example rendering

### DIFF
--- a/modules/localCommands.nix
+++ b/modules/localCommands.nix
@@ -11,16 +11,18 @@ with types;
       exit code 0 will result in success
       all other exit codes will result in failure
     '';
-    example = {
-      ping-wireguard = pkgs.writers.writeBash "ping-wireguard" ''
-        # ping this machine via wireguard network
-        ping -c 1 -W 5 10.5.23.42
-      '';
-      ping-tinc = pkgs.writers.writeBash "ping-tinc" ''
-        # ping this machine via tinc vpn
-        ping -c 1 -W 5 10.5.23.42
-      '';
-    };
+    example = lib.literalExpression ''
+      {
+        ping-wireguard = pkgs.writers.writeBash "ping-wireguard" '''
+          # ping this machine via wireguard network
+          ping -c 1 -W 5 10.5.23.42
+        ''';
+        ping-tinc = pkgs.writers.writeBash "ping-tinc" '''
+          # ping this machine via tinc vpn
+          ping -c 1 -W 5 10.5.23.42
+        ''';
+      };
+    '';
   };
 
   config = {


### PR DESCRIPTION
Hey hey :wave: 

Just found a trivial problem in the docs as it gets rendered.
The docs rendering logic will refuse to evaluate most `pkgs` attributes, so that we don't end up with arbitrary store paths appearing in the docs.

- Unblocks https://github.com/hercules-ci/flake.parts-website/pull/1507